### PR TITLE
[FIX] Allow File/Image Fields to be used

### DIFF
--- a/src/Http/Controllers/SettingsController.php
+++ b/src/Http/Controllers/SettingsController.php
@@ -6,14 +6,14 @@ use Illuminate\Routing\Controller;
 use Illuminate\Http\Request;
 use Epigra\NovaSettings\NovaSettingsTool;
 use Laravel\Nova\Contracts\Resolvable;
-use Laravel\Nova\Http\Requests\NovaRequest; 
+use Laravel\Nova\Http\Requests\NovaRequest;
 
 class SettingsController extends Controller
 {
     public function get(Request $request)
     {
         $fields = collect(NovaSettingsTool::getSettingsFields());
-        
+
         $fields->whereInstanceOf(Resolvable::class)->each(function (&$field) {
             if (!empty($field->attribute)) {
                 $field->resolve([$field->attribute => setting($field->attribute)]);
@@ -33,7 +33,10 @@ class SettingsController extends Controller
             $tempResource =  new \stdClass;
             $field->fill($request, $tempResource);
 
-            setting([$field->attribute => $tempResource->{$field->attribute} ]);
+            if (property_exists($tempResource, $field->attribute)) {
+                setting([$field->attribute => $tempResource->{$field->attribute} ]);
+            }
+
         });
 
         setting()->save();


### PR DESCRIPTION
I found out, that file fields will throw an error if saved. 

This fix can help.

Anyhow, I might have forgotten something – at least for me it serves well with this patch.