### PR TITLE
Restart queue

### DIFF
--- a/config/nova-settings.php
+++ b/config/nova-settings.php
@@ -1,0 +1,10 @@
+<?php
+
+    return [
+        /**
+         * Restart queue each time after settings are saved?
+         * Default: false
+         */
+
+        'restart_queue' => false
+    ];

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,7 @@ To publish the database migration(s) configuration of `akaunting/setting`
 
 ```bash
 php artisan vendor:publish --tag=setting
+php artisan vendor:publish --provider=Epigra\NovaSettings\Providers\NovaSettingsServiceProvider
 php artisan migrate
 ```
 
@@ -30,6 +31,7 @@ public function tools()
     ];
 }
 ```
+
 
 ## Usage
 
@@ -56,6 +58,14 @@ If you want the value of the setting to be formatted before it's returned, pass 
     return $value;
 });
 ```
+
+## Configuration
+
+### Restart queue after settings are saved
+
+If you project uses queue it is possible that you'll have to restart it each time settings are updated. 
+This feature is turned off per default. You may turn it on by changing `restart_queue` value from 
+`false` to `true` under `config/nova-settings.php`.
 
 # Credits
 

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ If you want the value of the setting to be formatted before it's returned, pass 
 
 ### Restart queue after settings are saved
 
-If you project uses queue it is possible that you'll have to restart it each time settings are updated. 
+If your project uses queue it is possible that you'll have to restart it each time settings are updated. 
 This feature is turned off per default. You may turn it on by changing `restart_queue` value from 
 `false` to `true` under `config/nova-settings.php`.
 

--- a/src/Http/Controllers/SettingsController.php
+++ b/src/Http/Controllers/SettingsController.php
@@ -5,6 +5,8 @@ namespace Epigra\NovaSettings\Http\Controllers;
 use Illuminate\Routing\Controller;
 use Illuminate\Http\Request;
 use Epigra\NovaSettings\NovaSettingsTool;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Log;
 use Laravel\Nova\Contracts\Resolvable;
 use Laravel\Nova\Http\Requests\NovaRequest;
 
@@ -40,6 +42,10 @@ class SettingsController extends Controller
         });
 
         setting()->save();
+
+        if (config('nova-settings.restart_queue', false)) {
+            Artisan::call('queue:restart');
+        }
 
         return response('', 204);
     }

--- a/src/Providers/NovaSettingsServiceProvider.php
+++ b/src/Providers/NovaSettingsServiceProvider.php
@@ -32,9 +32,10 @@ class NovaSettingsServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__ . '/../database/migrations' => database_path('migrations'),
             ], 'migrations');
-            $this->publishes([__DIR__ . '/../../config/nova-settings.php' => config_path('nova-settings.php')],
-                'config');
         }
+
+        $this->publishes([__DIR__ . '/../../config/nova-settings.php' => config_path('nova-settings.php')],
+            'config');
     }
 
     /**

--- a/src/Providers/NovaSettingsServiceProvider.php
+++ b/src/Providers/NovaSettingsServiceProvider.php
@@ -18,7 +18,7 @@ class NovaSettingsServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->loadViewsFrom(__DIR__ . '/../Resources/views', 'nova-settings');
-        
+
         $this->app->booted(function () {
             $this->routes();
         });
@@ -32,6 +32,8 @@ class NovaSettingsServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__ . '/../database/migrations' => database_path('migrations'),
             ], 'migrations');
+            $this->publishes([__DIR__ . '/../../config/nova-settings.php' => config_path('nova-settings.php')],
+                'config');
         }
     }
 


### PR DESCRIPTION
If project uses queue and it is not set to sync, queue jobs still have old values of settings after settings are updated until one calls `php artisan queue:restart`. 
So if the use of queues is extensive it may be important to automate this. That is why we've added `Artisan::call('queue:restart')` to `SettingsController::save` method. This call is controlled by a config value `restart_queue` under `config/nova-settings.php` that is per default `false`. 